### PR TITLE
Test Output value injection during CREATE/UPDATE request

### DIFF
--- a/.example/template.yaml
+++ b/.example/template.yaml
@@ -1,0 +1,40 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  Identifier:
+    Type: String
+    Default: LogGroupTestV1
+  ExposedOutputs:
+    Type: String
+    Default: MyTestOutput,MyTestOutput2
+Resources:
+  VpcStack:
+    Type: ProServe::CloudFormation::Stack
+    Properties:
+      AccountId: 847308954619
+      Region: eu-central-1
+      AssumeRoleName: CloudformationAdminRole
+      StackName: LogGroupTestP
+      ExposedOutputs: MyOutputTest
+      Template: | 
+          AWSTemplateFormatVersion: 2010-09-09
+          Parameters:
+            MyLogGroupName:
+              Type: String
+            ExposedOutputs:
+              Type: String
+          Resources:
+            MyNestedLogGroup:
+              Type: AWS::Logs::LogGroup
+              Properties:
+                LogGroupName: !Ref MyLogGroupName
+          Outputs:
+            MyOutputTest:
+              Value: !Ref MyNestedLogGroup
+      Parameters:
+        - Key: MyLogGroupName
+          Value:
+            Ref: Identifier
+        - Key: ExposedOutputs
+          Value: LeroLero
+    Metadata:
+      SamResourceId: VpcStack

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,8 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#parameters" title="Parameters">Parameters</a>" : <i>[ <a href="parameter.md">Parameter</a>, ... ]</i>,
         "<a href="#template" title="Template">Template</a>" : <i>String</i>,
         "<a href="#templateurl" title="TemplateUrl">TemplateUrl</a>" : <i>String</i>,
+        "<a href="#output" title="Output">Output</a>" : <i>String</i>,
+        "<a href="#exposedoutputs" title="ExposedOutputs">ExposedOutputs</a>" : <i>String</i>,
         "<a href="#tags" title="Tags">Tags</a>" : <i>[ <a href="tag.md">Tag</a>, ... ]</i>
     }
 }
@@ -42,6 +44,8 @@ Properties:
       - <a href="parameter.md">Parameter</a></i>
     <a href="#template" title="Template">Template</a>: <i>String</i>
     <a href="#templateurl" title="TemplateUrl">TemplateUrl</a>: <i>String</i>
+    <a href="#output" title="Output">Output</a>: <i>String</i>
+    <a href="#exposedoutputs" title="ExposedOutputs">ExposedOutputs</a>: <i>String</i>
     <a href="#tags" title="Tags">Tags</a>: <i>
       - <a href="tag.md">Tag</a></i>
 </pre>
@@ -132,6 +136,22 @@ _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
+#### Output
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### ExposedOutputs
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
 #### Tags
 
 An array of key-value pairs to apply to this resource.
@@ -157,8 +177,4 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 #### StackId
 
 Returns the <code>StackId</code> value.
-
-#### Output
-
-Returns the <code>Output</code> value.
 

--- a/proserve-cloudformation-stack.json
+++ b/proserve-cloudformation-stack.json
@@ -1,7 +1,7 @@
 {
     "typeName": "ProServe::CloudFormation::Stack",
     "description": "Resource schema for cross-account stack deployments.",
-    "sourceUrl": "https://github.com/curlim/aws-cloudformation-stack.git",
+    "sourceUrl": "https://github.com/drandrel/aws-cloudformation-stack.git",
     "definitions": {
         "Tag": {
             "description": "A key-value pair to associate with a resource.",
@@ -95,6 +95,9 @@
         "Output": {
             "type": "string"
         },
+        "ExposedOutputs": {
+            "type": "string"
+        },
         "Tags": {
             "description": "An array of key-value pairs to apply to this resource.",
             "type": "array",
@@ -112,7 +115,8 @@
                 "AccountId",
                 "AssumeRoleName",
                 "StackName",
-                "Template"
+                "Template",
+                "ExposedOutputs"
             ]
         },
         {
@@ -120,7 +124,8 @@
                 "AccountId",
                 "AssumeRoleName",
                 "StackName",
-                "TemplateUrl"
+                "TemplateUrl",
+                "ExposedOutputs"
             ]
         }
     ],
@@ -128,22 +133,29 @@
         "/properties/AccountId",
         "/properties/StackName",
         "/properties/AssumeRolePath",
-        "/properties/AssumeRoleName"
+        "/properties/AssumeRoleName",
+        "/properties/Output",
+        "/properties/ExposedOutputs"
     ],
     "readOnlyProperties": [
-        "/properties/StackId",
-        "/properties/Output"
+        "/properties/StackId"
+    ],
+    "additionalIdentifiers": [
+        [
+            "/properties/ExposedOutputs",
+            "/properties/Output"
+        ]
     ],
     "primaryIdentifier": [
         "/properties/StackId"
     ],
     "handlers": {
         "create": {
-            "permissions": ["sts:AssumeRole"],
+            "permissions": ["sts:AssumeRole", "cloudformation:DescribeStackResource", "cloudformation:GetTemplateSummary", "cloudformation:DescribeType"],
             "timeoutInMinutes": 300
         },
         "read": {
-            "permissions": ["sts:AssumeRole"]
+            "permissions": ["sts:AssumeRole", "cloudformation:DescribeStackResource", "cloudformation:DescribeStackResource", "cloudformation:DescribeType"]
         },
         "update": {
             "permissions": ["sts:AssumeRole"],
@@ -154,7 +166,7 @@
             "timeoutInMinutes": 300
         },
         "list": {
-            "permissions": ["sts:AssumeRole"]
+            "permissions": ["sts:AssumeRole", "cloudformation:DescribeStackResource", "cloudformation:DescribeStackResource", "cloudformation:ListTypes", "cloudformation:ListTypeVersions"]
         }
     }
 }

--- a/quickstart/cfn-provider-registration.yaml
+++ b/quickstart/cfn-provider-registration.yaml
@@ -74,6 +74,7 @@ Resources:
       LoggingConfig:
           LogGroupName: !Ref CfnResourceLogGroup
           LogRoleArn: !GetAtt CfnLogAndMetricsDeliveryRole.Arn
+
   CfnResourceProviderDefaultVersion:
     Type: AWS::CloudFormation::ResourceDefaultVersion
     Properties:

--- a/resource-role.yaml
+++ b/resource-role.yaml
@@ -30,6 +30,11 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "cloudformation:DescribeStackResource"
+                - "cloudformation:DescribeType"
+                - "cloudformation:GetTemplateSummary"
+                - "cloudformation:ListTypeVersions"
+                - "cloudformation:ListTypes"
                 - "sts:AssumeRole"
                 Resource: "*"
 Outputs:

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -1,0 +1,11 @@
+version = 0.1
+[default]
+[default.deploy]
+[default.deploy.parameters]
+stack_name = "drandrel-aws-cloudformation-stack"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-1qyvwvhbngv09"
+s3_prefix = "drandrel-aws-cloudformation-stack"
+region = "eu-central-1"
+confirm_changeset = true
+capabilities = "CAPABILITY_IAM"
+image_repositories = []

--- a/src/main/java/software/amazon/proserve/cloudformation/stack/ReadHandler.java
+++ b/src/main/java/software/amazon/proserve/cloudformation/stack/ReadHandler.java
@@ -22,9 +22,15 @@ public class ReadHandler extends BaseHandlerStd {
 
         this.logger = logger;
         final ResourceModel model = request.getDesiredResourceState();
+        /** for some reason the role and accountIid and region was not been fetched in the READ call, so for testing I actually made it statically defined
+         final String rolePath = "CloudformationAdminRole";
+         final String region = "eu-central-1";
+        */
         final String rolePath = model.getAssumeRolePath() == null ? "" : model.getAssumeRolePath();
         final String roleArn = String.format("arn:aws:iam::%s:role/%s%s", model.getAccountId(), rolePath, model.getAssumeRoleName());
         final String region = model.getRegion() != null ? model.getRegion() : request.getRegion();
+
+
         AmazonWebServicesClientProxy _proxy = retrieveCrossAccountProxy(
                 proxy,
                 (LoggerProxy) logger,
@@ -35,5 +41,7 @@ public class ReadHandler extends BaseHandlerStd {
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> describeStacks(_proxy, _proxyClient, progress, progress.getResourceModel(), logger, callbackContext))
                 .then(progress -> ProgressEvent.defaultSuccessHandler(progress.getResourceModel()));
+
+
     }
 }

--- a/src/main/java/software/amazon/proserve/cloudformation/stack/util/ClientBuilder.java
+++ b/src/main/java/software/amazon/proserve/cloudformation/stack/util/ClientBuilder.java
@@ -45,7 +45,7 @@ public class ClientBuilder {
                             .backoffStrategy(BackoffStrategy.defaultThrottlingStrategy())
                             .throttlingBackoffStrategy(BackoffStrategy.defaultThrottlingStrategy())
                             .numRetries(MAX_RETRIES)
-                            .retryCondition(OrRetryCondition.create(RetryCondition.defaultRetryCondition(),
+                             .retryCondition(OrRetryCondition.create(RetryCondition.defaultRetryCondition(),
                                     LazyHolder.ClientRetryCondition.create()))
                             .build())
                     .build())

--- a/template.yml
+++ b/template.yml
@@ -4,8 +4,8 @@ Description: AWS SAM template for the ProServe::CloudFormation::Stack resource t
 
 Globals:
   Function:
-    Timeout: 180  # docker start-up times can be long for SAM CLI
-    MemorySize: 256
+    Timeout: 360  # docker start-up times can be long for SAM CLI
+    MemorySize: 1024
 
 Resources:
   TypeFunction:


### PR DESCRIPTION
Hi @curlim, "Petar" adviced me to open a PR as the best way to communicate with you. So I hope it's fine to have this PR, please reject it after checking the content.
Context:
 - We are trying to introduce a logic in the CREATE request which consist in reading a list of Inputs in the template, these Inputs are supposed to be used as keys for discovering values in the CREATE business logic, then inject it as Output in the response. 

Regarding the test:
- What I was trying to achieve by setting values statically, is to see if I was able to set the Output I mention above, however during the tests, I wasn't able to really set the values, it seems like I'm missing something either in the config or in the request flow.

Thank you so much in advance for the support.